### PR TITLE
Allow partial scrolling to better support multiline log messages

### DIFF
--- a/Sentinel/Views/Gui/LogMessagesControl.xaml
+++ b/Sentinel/Views/Gui/LogMessagesControl.xaml
@@ -23,7 +23,8 @@
 	<Grid x:Name="LayoutRoot">
 		<ListView x:Name="messages"
 				  Grid.Column="0"
-				  ItemsSource="{Binding Messages}">
+				  ItemsSource="{Binding Messages}"
+                  ScrollViewer.CanContentScroll="True">
 			<ListView.View>
 				<GridView>
 					<Controls:FixedWidthColumn Header="Type">


### PR DESCRIPTION
This setting enables partial scrolling, which is essential when some log entries span multiple lines.